### PR TITLE
fix: Mopidy plugin must expose version number

### DIFF
--- a/mopidy_pummeluff/__init__.py
+++ b/mopidy_pummeluff/__init__.py
@@ -3,12 +3,14 @@ Mopidy Pummeluff Python module.
 '''
 
 import os
-
+import pkg_resources
 import mopidy
 
 from .frontend import PummeluffFrontend
 from .web import LatestHandler, RegistryHandler, RegisterHandler, UnregisterHandler, \
     ActionClassesHandler
+
+__version__ = pkg_resources.get_distribution('Mopidy-Pummeluff').version
 
 
 def app_factory(config, core):  # pylint: disable=unused-argument
@@ -37,6 +39,7 @@ class Extension(mopidy.ext.Extension):
 
     dist_name = 'Mopidy-Pummeluff'
     ext_name = 'pummeluff'
+    version = __version__
 
     def get_default_config(self):  # pylint: disable=no-self-use
         '''


### PR DESCRIPTION
https://github.com/confirm/mopidy-pummeluff/pull/26/files